### PR TITLE
Improved commandline instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,26 @@
 # wdomirror
 
-wdomirror utilizes the wlroots dmabuf export protocol to create a mirror of an outout 
-with as little overhead as possible. 
+wdomirror utilizes the wlroots dmabuf export protocol to create a mirror of an outout
+with as little overhead as possible.
 
 ## Building
 
-meson build
-ninja -C build
+```bash
+meson build && ninja -C build
+```
 
 ## Usage
 
 List the outputs and their IDs.
 
-    ./wdomirror
-
+```bash
+./wdomirror
+```
 Create the mirror
 
-    ./wdomirror $ID
+```bash
+./wdomirror $ID
+```
 
 wdomirror does not preserve the aspect ration, so make sure to set the size of the mirror window correctly.
 For fullscreen, make sure that both source and target outputs have the same aspect ratio.


### PR DESCRIPTION
The build instructions were not in a code block and they where printed on 1 line, which might be misleading.