### PR TITLE
fix: markdown formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,18 +5,24 @@ with as little overhead as possible.
 
 ## Building
 
+```
 meson build
 ninja -C build
+```
 
 ## Usage
 
 List the outputs and their IDs.
 
-    ./wdomirror
+```
+./wdomirror
+```
 
 Create the mirror
 
-    ./wdomirror $ID
+```
+./wdomirror $ID
+```
 
 wdomirror does not preserve the aspect ration, so make sure to set the size of the mirror window correctly.
 For fullscreen, make sure that both source and target outputs have the same aspect ratio.


### PR DESCRIPTION
Putting building commands inside backticks helps with with readability on GitHub. 