### PR TITLE
fix: missing field initializer

### DIFF
--- a/main.c
+++ b/main.c
@@ -409,9 +409,14 @@ xdg_toplevel_handle_close(void *data, struct xdg_toplevel *xdg_toplevel)
   ctx->quit = true;
 }
 
+static void
+xdg_toplevel_handle_configure_bounds(void *data, struct xdg_toplevel *toplevel, int32_t width, int32_t height)
+{ }
+
 static const struct xdg_toplevel_listener xdg_toplevel_listener = {
   xdg_toplevel_handle_configure,
   xdg_toplevel_handle_close,
+  xdg_toplevel_handle_configure_bounds
 };
 
 


### PR DESCRIPTION
Trying to compile the code with `gcc v11.2.0`, `wayland-client v1.20.0` and `wayland-protocols v1.25` throws 


```
[18/19] Compiling C object wdomirror.p/main.c.o
FAILED: wdomirror.p/main.c.o
cc -Iwdomirror.p -I. -I.. -Iprotocol -I../protocol -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wextra -Werror -std=c11 -O0 -g -Wno-missing-braces -Wno-unused-parameter -MD -MQ wdomirror.p/main.c.o -MF wdomirror.p/main.c.o.d -o wdomirror.p/main.c.o -c ../main.c
../main.c:415:1: error: missing initializer for field ‘configure_bounds’ of ‘const struct xdg_toplevel_listener’ [-Werror=missing-field-initializers]
  415 | };
      | ^
In file included from ../main.c:16:
wdomirror.p/xdg-shell-client-protocol.h:1388:16: note: ‘configure_bounds’ declared here
 1388 |         void (*configure_bounds)(void *data,
      |                ^~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
ninja: build stopped: subcommand failed.
```